### PR TITLE
Add GA4 analytics tracking

### DIFF
--- a/docs/avg-benefit-by-decile.html
+++ b/docs/avg-benefit-by-decile.html
@@ -6,6 +6,13 @@
     <title>Average Benefit by Income Decile - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/avg-benefit-by-decile.html
+++ b/docs/avg-benefit-by-decile.html
@@ -13,6 +13,48 @@
         gtag('js', new Date());
         gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
     </script>
+    <script>
+    (function() {
+      var TOOL_NAME = 'stronger-start-calc';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {};
+      window.addEventListener('scroll', function() {
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {
+          if (pct >= m && !scrollFired[m]) {
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+          }
+        });
+      }, { passive: true });
+
+      [30, 60, 120, 300].forEach(function(sec) {
+        setTimeout(function() {
+          if (document.visibilityState !== 'hidden') {
+            window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+          }
+        }, sec * 1000);
+      });
+
+      document.addEventListener('click', function(e) {
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {
+            window.gtag('event', 'outbound_click', {
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            });
+          }
+        } catch (err) {}
+      });
+    })();
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/avg-benefit-by-decile.html
+++ b/docs/avg-benefit-by-decile.html
@@ -6,12 +6,12 @@
     <title>Average Benefit by Income Decile - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+        gtag('config', 'G-2YHG89FY0N', { tool_name: 'stronger-start-calc' });
     </script>
     <script>
     (function() {

--- a/docs/baseline-reform-comparison.html
+++ b/docs/baseline-reform-comparison.html
@@ -6,12 +6,12 @@
     <title>Baseline vs Reform - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+        gtag('config', 'G-2YHG89FY0N', { tool_name: 'stronger-start-calc' });
     </script>
     <script>
     (function() {

--- a/docs/baseline-reform-comparison.html
+++ b/docs/baseline-reform-comparison.html
@@ -13,6 +13,48 @@
         gtag('js', new Date());
         gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
     </script>
+    <script>
+    (function() {
+      var TOOL_NAME = 'stronger-start-calc';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {};
+      window.addEventListener('scroll', function() {
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {
+          if (pct >= m && !scrollFired[m]) {
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+          }
+        });
+      }, { passive: true });
+
+      [30, 60, 120, 300].forEach(function(sec) {
+        setTimeout(function() {
+          if (document.visibilityState !== 'hidden') {
+            window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+          }
+        }, sec * 1000);
+      });
+
+      document.addEventListener('click', function(e) {
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {
+            window.gtag('event', 'outbound_click', {
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            });
+          }
+        } catch (err) {}
+      });
+    })();
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/baseline-reform-comparison.html
+++ b/docs/baseline-reform-comparison.html
@@ -6,6 +6,13 @@
     <title>Baseline vs Reform - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/net-income-change.html
+++ b/docs/net-income-change.html
@@ -13,6 +13,48 @@
         gtag('js', new Date());
         gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
     </script>
+    <script>
+    (function() {
+      var TOOL_NAME = 'stronger-start-calc';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {};
+      window.addEventListener('scroll', function() {
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {
+          if (pct >= m && !scrollFired[m]) {
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+          }
+        });
+      }, { passive: true });
+
+      [30, 60, 120, 300].forEach(function(sec) {
+        setTimeout(function() {
+          if (document.visibilityState !== 'hidden') {
+            window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+          }
+        }, sec * 1000);
+      });
+
+      document.addEventListener('click', function(e) {
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {
+            window.gtag('event', 'outbound_click', {
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            });
+          }
+        } catch (err) {}
+      });
+    })();
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/net-income-change.html
+++ b/docs/net-income-change.html
@@ -6,6 +6,13 @@
     <title>Net Income Change - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/net-income-change.html
+++ b/docs/net-income-change.html
@@ -6,12 +6,12 @@
     <title>Net Income Change - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+        gtag('config', 'G-2YHG89FY0N', { tool_name: 'stronger-start-calc' });
     </script>
     <script>
     (function() {

--- a/docs/winners-by-decile.html
+++ b/docs/winners-by-decile.html
@@ -13,6 +13,48 @@
         gtag('js', new Date());
         gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
     </script>
+    <script>
+    (function() {
+      var TOOL_NAME = 'stronger-start-calc';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {};
+      window.addEventListener('scroll', function() {
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {
+          if (pct >= m && !scrollFired[m]) {
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+          }
+        });
+      }, { passive: true });
+
+      [30, 60, 120, 300].forEach(function(sec) {
+        setTimeout(function() {
+          if (document.visibilityState !== 'hidden') {
+            window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+          }
+        }, sec * 1000);
+      });
+
+      document.addEventListener('click', function(e) {
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {
+            window.gtag('event', 'outbound_click', {
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            });
+          }
+        } catch (err) {}
+      });
+    })();
+    </script>
     <style>
         body {
             margin: 0;

--- a/docs/winners-by-decile.html
+++ b/docs/winners-by-decile.html
@@ -6,12 +6,12 @@
     <title>Winners by Income Decile - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+        gtag('config', 'G-2YHG89FY0N', { tool_name: 'stronger-start-calc' });
     </script>
     <script>
     (function() {

--- a/docs/winners-by-decile.html
+++ b/docs/winners-by-decile.html
@@ -6,6 +6,13 @@
     <title>Winners by Income Decile - Stronger Start for Working Families Act</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-91M4529HE7', { tool_name: 'stronger-start-calc' });
+    </script>
     <style>
         body {
             margin: 0;

--- a/generate_dynamic_charts.py
+++ b/generate_dynamic_charts.py
@@ -27,6 +27,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     <title>{title}</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){{dataLayer.push(arguments);}}
+        gtag('js', new Date());
+        gtag('config', 'G-91M4529HE7', {{ tool_name: 'stronger-start-calc' }});
+    </script>
     <style>
         body {{
             margin: 0;

--- a/generate_dynamic_charts.py
+++ b/generate_dynamic_charts.py
@@ -27,12 +27,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     <title>{title}</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){{dataLayer.push(arguments);}}
         gtag('js', new Date());
-        gtag('config', 'G-91M4529HE7', {{ tool_name: 'stronger-start-calc' }});
+        gtag('config', 'G-2YHG89FY0N', {{ tool_name: 'stronger-start-calc' }});
     </script>
     <script>
     (function() {{

--- a/generate_dynamic_charts.py
+++ b/generate_dynamic_charts.py
@@ -34,6 +34,48 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         gtag('js', new Date());
         gtag('config', 'G-91M4529HE7', {{ tool_name: 'stronger-start-calc' }});
     </script>
+    <script>
+    (function() {{
+      var TOOL_NAME = 'stronger-start-calc';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {{}};
+      window.addEventListener('scroll', function() {{
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {{
+          if (pct >= m && !scrollFired[m]) {{
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', {{ percent: m, tool_name: TOOL_NAME }});
+          }}
+        }});
+      }}, {{ passive: true }});
+
+      [30, 60, 120, 300].forEach(function(sec) {{
+        setTimeout(function() {{
+          if (document.visibilityState !== 'hidden') {{
+            window.gtag('event', 'time_on_tool', {{ seconds: sec, tool_name: TOOL_NAME }});
+          }}
+        }}, sec * 1000);
+      }});
+
+      document.addEventListener('click', function(e) {{
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {{
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {{
+            window.gtag('event', 'outbound_click', {{
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            }});
+          }}
+        }} catch (err) {{}}
+      }});
+    }})();
+    </script>
     <style>
         body {{
             margin: 0;

--- a/generate_post.py
+++ b/generate_post.py
@@ -23,12 +23,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     <title>{title}</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){{dataLayer.push(arguments);}}
         gtag('js', new Date());
-        gtag('config', 'G-91M4529HE7', {{ tool_name: 'stronger-start-calc' }});
+        gtag('config', 'G-2YHG89FY0N', {{ tool_name: 'stronger-start-calc' }});
     </script>
     <script>
     (function() {{

--- a/generate_post.py
+++ b/generate_post.py
@@ -23,6 +23,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     <title>{title}</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){{dataLayer.push(arguments);}}
+        gtag('js', new Date());
+        gtag('config', 'G-91M4529HE7', {{ tool_name: 'stronger-start-calc' }});
+    </script>
     <style>
         body {{
             margin: 0;

--- a/generate_post.py
+++ b/generate_post.py
@@ -30,6 +30,48 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         gtag('js', new Date());
         gtag('config', 'G-91M4529HE7', {{ tool_name: 'stronger-start-calc' }});
     </script>
+    <script>
+    (function() {{
+      var TOOL_NAME = 'stronger-start-calc';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {{}};
+      window.addEventListener('scroll', function() {{
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {{
+          if (pct >= m && !scrollFired[m]) {{
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', {{ percent: m, tool_name: TOOL_NAME }});
+          }}
+        }});
+      }}, {{ passive: true }});
+
+      [30, 60, 120, 300].forEach(function(sec) {{
+        setTimeout(function() {{
+          if (document.visibilityState !== 'hidden') {{
+            window.gtag('event', 'time_on_tool', {{ seconds: sec, tool_name: TOOL_NAME }});
+          }}
+        }}, sec * 1000);
+      }});
+
+      document.addEventListener('click', function(e) {{
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {{
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {{
+            window.gtag('event', 'outbound_click', {{
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            }});
+          }}
+        }} catch (err) {{}}
+      }});
+    }})();
+    </script>
     <style>
         body {{
             margin: 0;


### PR DESCRIPTION
## Summary
- Adds GA4 tracking (shared org ID `G-2YHG89FY0N`) with `tool_name=stronger-start-calc` on all events so this tool rolls up into the PolicyEngine-wide analytics dashboard.
- Events: pageview, `scroll_depth` (25/50/75/100%), `time_on_tool` (30/60/120/300s, visible tabs only), `outbound_click` (any link off this host).

## Follow-ups (out of scope)
- Tool-specific events: calculator submit, input changes, share/embed CTAs

## Test plan
- [ ] `gtag/js` loads in browser network tab
- [ ] `tool_name: stronger-start-calc` appears in GA4 DebugView on pageview
- [ ] Scroll to bottom: `scroll_depth` events fire at 25/50/75/100
- [ ] Wait 30s+ on the page: `time_on_tool` events fire
- [ ] Click an external link: `outbound_click` event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)